### PR TITLE
Moving room into address field

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 ---
 layout: workshop
 root: .
-venue: Auditorium Maximum, Jagiellonian University
-address: ul. Krupnicza 33, Kraków
+venue: Jagiellonian University
+address: Auditorium Maximum, ul. Krupnicza 33, Kraków
 country: Poland
 language: pl
 latlng:  50.062828,19.925101


### PR DESCRIPTION
Using 'venue' just for the site name, putting the room into the address field so that the main web site will render more cleanly.
